### PR TITLE
cmake 3.22.1

### DIFF
--- a/recipe/SSLTest.cmake
+++ b/recipe/SSLTest.cmake
@@ -1,6 +1,6 @@
 set(FILE_NAME "LICENSE.txt")
 set(DOWNLOAD_URL "https://raw.githubusercontent.com/conda-forge/cmake-feedstock/master/${FILE_NAME}")
-set(EXPECTED_SHA256 "1b17a4bbffec8473f2c0be83f697c2e533f8e1170ed74525ceeee24ddd887afd")
+set(EXPECTED_SHA256 "b5904c52eaee178d332cc0cb2e3795f68af62a72bfb090ea32c493abd88af0d6")
 
 file(DOWNLOAD ${DOWNLOAD_URL} ${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}
  SHOW_PROGRESS

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -41,9 +41,9 @@ pushd cmake
 
   make install -j${CPU_COUNT}
 
-  if [[ "${target_platform}" == osx-* ]]; then
-    echo "No removal of .in files for osx ..."
-  else
+  # Kludge for conda-build, which tries to detect MacOS binaries on this architecture
+  # and then silently crashes ...
+  if [[ "${target_platform}" == linux-s390x ]]; then
     rm -rf $PREFIX/share/cmake-3.22/Modules/Internal/CPack/CPack.OSXScriptLauncher.in
   fi
 popd

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -41,5 +41,10 @@ pushd cmake
 
   make install -j${CPU_COUNT}
 
+  if [[ "${target_platform}" == osx-* ]]; then
+    echo "No removal of .in files for osx ..."
+  else
+    rm -rf $PREFIX/share/cmake-3.22/Modules/Internal/CPack/CPack.OSXScriptLauncher.in
+  fi
 popd
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,9 @@ source:
   # patches:
   #   - patches/git/0001-Add-more-debug-logging-to-cmFindCommon.patch
   - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows-i386.zip  # [win32]
-    sha256: aa0fdf103ec93ad462a7d37e7b91a2e1739efb947af648c459efed133b70343b  # [win32]
+    sha256: f53494e3b35e5a1177ad55c28763eb5bb45772c1d80778c0f96c45ce4376b6e8  # [win32]
   - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows-x86_64.zip  # [win64]
-    sha256: aa0fdf103ec93ad462a7d37e7b91a2e1739efb947af648c459efed133b70343b  # [win64]
+    sha256: 35fbbb7d9ffa491834bbc79cdfefc6c360088a3c9bf55c29d111a5afa04cdca3  # [win64]
     folder: cmake-bin  # [win]
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
     - ccmake --version  # [unix]
 
 about:
-  home: http://www.cmake.org/
+  home: https://cmake.org/
   license: BSD-3-Clause
   license_family: BSD
   license_file:
@@ -65,6 +65,8 @@ about:
     - cmake/Utilities/cmlibarchive/COPYING
     - cmake/Utilities/cmjsoncpp/LICENSE
   summary: CMake is an extensible, open-source system that manages the build process
+  dev_url: https://gitlab.kitware.com/cmake/cmake
+  doc_url: https://cmake.org/documentation/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,7 @@ source:
 build:
   number: 0
   skip: True  # [win and vc<14]
-  detect_binary_files_with_prefix: False  # [not (linux and s390x)]
-  detect_binary_files_with_prefix: True   # [linux and s390x]
+  detect_binary_files_with_prefix: False
   ignore_run_exports:
     - vc
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,8 @@ source:
   - url: https://gitlab.kitware.com/cmake/cmake/-/archive/v{{ version }}/cmake-v{{ version }}.tar.bz2
     sha256: aa0fdf103ec93ad462a7d37e7b91a2e1739efb947af648c459efed133b70343b
     folder: cmake
-    patches:
-      - patches/git/0001-Add-more-debug-logging-to-cmFindCommon.patch
+  #  patches:
+  #   - patches/git/0001-Add-more-debug-logging-to-cmFindCommon.patch
   #   - patches/3.16.2/0001-find_-Add-debug-logging-infrastructure.patch
   #   - patches/3.16.2/0002-find_-Use-debug-logging-infrastructure.patch
   #   - patches/3.16.2/0003-Add-more-debug-logging-to-cmFindCommon.patch
@@ -38,13 +38,12 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - make            # [unix]
-    - patch           # [not win]
-    - m2-patch        # [win]
+  #  - patch           # [not win]
+  #  - m2-patch        # [win]
     - m2-gcc-libs     # [win]
     - jom             # [win]
     # - cmake           # [build_platform != target_platform]
     # - git
-
   host:
     - libcurl         # [unix]
     - expat           # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.19.6" %}
+{% set version = "3.22.1" %}
 
 package:
   name: cmake
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://gitlab.kitware.com/cmake/cmake/-/archive/v{{ version }}/cmake-v{{ version }}.tar.bz2
-    sha256: 7ed798ab8ba99f84b09c1207d3e5db527d9b356a5b3a1d7f8cd759f7dfb8c4a7
+    sha256: aa0fdf103ec93ad462a7d37e7b91a2e1739efb947af648c459efed133b70343b
     folder: cmake
     patches:
       - patches/git/0001-Add-more-debug-logging-to-cmFindCommon.patch
@@ -21,9 +21,9 @@ source:
   # patches:
   #   - patches/git/0001-Add-more-debug-logging-to-cmFindCommon.patch
   - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-win32-x86.zip  # [win32]
-    sha256: e0cd5a2ec34bd7954238ca2a4c7d3c67c49dac2ea285be3c098662a005ad46e0  # [win32]
+    sha256: aa0fdf103ec93ad462a7d37e7b91a2e1739efb947af648c459efed133b70343b  # [win32]
   - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-win64-x64.zip  # [win64]
-    sha256: 6883a07f95ae01360d24f1341622f71b3e6ddc6251381752cd4a4d9d4d704c67  # [win64]
+    sha256: aa0fdf103ec93ad462a7d37e7b91a2e1739efb947af648c459efed133b70343b  # [win64]
     folder: cmake-bin  # [win]
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,9 +20,9 @@ source:
   # git_url: 'https://gitlab.kitware.com/cmake/cmake'
   # patches:
   #   - patches/git/0001-Add-more-debug-logging-to-cmFindCommon.patch
-  - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-win32-x86.zip  # [win32]
+  - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows-i386.zip  # [win32]
     sha256: aa0fdf103ec93ad462a7d37e7b91a2e1739efb947af648c459efed133b70343b  # [win32]
-  - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-win64-x64.zip  # [win64]
+  - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows-x86-64.zip  # [win64]
     sha256: aa0fdf103ec93ad462a7d37e7b91a2e1739efb947af648c459efed133b70343b  # [win64]
     folder: cmake-bin  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,18 +8,6 @@ source:
   - url: https://gitlab.kitware.com/cmake/cmake/-/archive/v{{ version }}/cmake-v{{ version }}.tar.bz2
     sha256: aa0fdf103ec93ad462a7d37e7b91a2e1739efb947af648c459efed133b70343b
     folder: cmake
-  #  patches:
-  #   - patches/git/0001-Add-more-debug-logging-to-cmFindCommon.patch
-  #   - patches/3.16.2/0001-find_-Add-debug-logging-infrastructure.patch
-  #   - patches/3.16.2/0002-find_-Use-debug-logging-infrastructure.patch
-  #   - patches/3.16.2/0003-Add-more-debug-logging-to-cmFindCommon.patch
-  # Not until Python 3.8 on Windows: https://github.com/WorksApplications/SudachiPy/issues/107#issuecomment-564510365
-  # - path: 'W:/src/cmake'
-  #   path_via_symlink: True
-  # git_url: 'C:/opt/Shared.local/src/cmake'
-  # git_url: 'https://gitlab.kitware.com/cmake/cmake'
-  # patches:
-  #   - patches/git/0001-Add-more-debug-logging-to-cmFindCommon.patch
   - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows-i386.zip  # [win32]
     sha256: f53494e3b35e5a1177ad55c28763eb5bb45772c1d80778c0f96c45ce4376b6e8  # [win32]
   - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows-x86_64.zip  # [win64]
@@ -29,7 +17,8 @@ source:
 build:
   number: 0
   skip: True  # [win and vc<14]
-  detect_binary_files_with_prefix: False
+  detect_binary_files_with_prefix: False  # [not (linux and s390x)]
+  detect_binary_files_with_prefix: True   # [linux and s390x]
   ignore_run_exports:
     - vc
 
@@ -38,12 +27,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - make            # [unix]
-  #  - patch           # [not win]
-  #  - m2-patch        # [win]
     - m2-gcc-libs     # [win]
     - jom             # [win]
-    # - cmake           # [build_platform != target_platform]
-    # - git
   host:
     - libcurl         # [unix]
     - expat           # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,9 +20,9 @@ source:
   # git_url: 'https://gitlab.kitware.com/cmake/cmake'
   # patches:
   #   - patches/git/0001-Add-more-debug-logging-to-cmFindCommon.patch
-  - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows_i386.zip  # [win32]
+  - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows-i386.zip  # [win32]
     sha256: aa0fdf103ec93ad462a7d37e7b91a2e1739efb947af648c459efed133b70343b  # [win32]
-  - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows_x86-64.zip  # [win64]
+  - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows-x86_64.zip  # [win64]
     sha256: aa0fdf103ec93ad462a7d37e7b91a2e1739efb947af648c459efed133b70343b  # [win64]
     folder: cmake-bin  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,9 +20,9 @@ source:
   # git_url: 'https://gitlab.kitware.com/cmake/cmake'
   # patches:
   #   - patches/git/0001-Add-more-debug-logging-to-cmFindCommon.patch
-  - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows-i386.zip  # [win32]
+  - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows_i386.zip  # [win32]
     sha256: aa0fdf103ec93ad462a7d37e7b91a2e1739efb947af648c459efed133b70343b  # [win32]
-  - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows-x86-64.zip  # [win64]
+  - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows_x86-64.zip  # [win64]
     sha256: aa0fdf103ec93ad462a7d37e7b91a2e1739efb947af648c459efed133b70343b  # [win64]
     folder: cmake-bin  # [win]
 


### PR DESCRIPTION
Update cmake to 3.22.1

Actions:
1. Remove old unused patches
2. Fix source urls
3. Remove `(m2)-patch`
4. Fix the issue with `$PREFIX/share/cmake-3.22/Modules/Internal/CPack/CPack.OSXScriptLauncher.in` on `s390x`