### PR TITLE
v3.31.2

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -14,7 +14,7 @@ if "%PY_INTERP_DEBUG%" neq "" (
 
 dir /p %LIBRARY_PREFIX%\lib
 
-cmake -LAH -G"NMake Makefiles"                               ^
+cmake -LAH -G Ninja                                          ^
     -DCMAKE_BUILD_TYPE=%CMAKE_CONFIG%                        ^
     -DCMAKE_FIND_ROOT_PATH="%LIBRARY_PREFIX%"                ^
     -DCMAKE_PREFIX_PATH="%PREFIX%"                           ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,37 +1,22 @@
 #!/bin/sh
 set -ex
 
-CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_FIND_ROOT_PATH=${PREFIX} -DCMAKE_INSTALL_RPATH=${PREFIX}/lib"
-CMAKE_ARGS="$CMAKE_ARGS -DCURSES_INCLUDE_PATH=${PREFIX}/include -DBUILD_CursesDialog=ON -DCMake_HAVE_CXX_MAKE_UNIQUE:INTERNAL=FALSE"
-CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_PREFIX_PATH=${PREFIX}"
+cmake -LAH -G Ninja ${CMAKE_ARGS} \
+    -DCMAKE_BUILD_TYPE:STRING=Release \
+    -DCMAKE_PREFIX_PATH=${PREFIX} \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_INSTALL_RPATH=${PREFIX}/lib \
+    -DCURSES_INCLUDE_PATH=${PREFIX}/include \
+    -DCMAKE_USE_SYSTEM_LIBRARIES=ON \
+    -DCMAKE_USE_SYSTEM_JSONCPP=OFF \
+    -DCMAKE_USE_SYSTEM_LIBARCHIVE=OFF \
+    -DCMAKE_USE_SYSTEM_CPPDAP=OFF \
+    -DCMAKE_USE_SYSTEM_LIBRARY_JSONCPP=OFF \
+    -DCMAKE_USE_SYSTEM_LIBRARY_LIBARCHIVE=OFF \
+    -DCMAKE_USE_SYSTEM_LIBRARY_CPPDAP=OFF \
+    -DBUILD_CursesDialog=ON \
+    -DBUILD_QtDialog=OFF \
+    . || (cat TryRunResults.cmake; false)
 
-if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]]; then
-   if [[ "$target_platform" == osx-* ]] && [[ "$MACOSX_DEPLOYMENT_TARGET" == 11.* || "$MACOSX_DEPLOYMENT_TARGET" == "10.15" ]]; then
-       CMAKE_ARGS="$CMAKE_ARGS -DCMake_HAVE_CXX_FILESYSTEM=1"
-   else
-       CMAKE_ARGS="$CMAKE_ARGS -DCMake_HAVE_CXX_FILESYSTEM=0"
-   fi
-   cmake ${CMAKE_ARGS} \
-       -DCMAKE_VERBOSE_MAKEFILE=1 \
-       -DCMAKE_INSTALL_PREFIX=$PREFIX \
-       -DCMAKE_USE_SYSTEM_LIBRARIES=ON \
-       -DBUILD_QtDialog=OFF \
-       -DCMAKE_USE_SYSTEM_LIBRARY_LIBARCHIVE=OFF \
-       -DCMAKE_USE_SYSTEM_LIBRARY_JSONCPP=OFF \
-       . || (cat TryRunResults.cmake; false)
-else
-  ./bootstrap \
-       --verbose \
-       --prefix="${PREFIX}" \
-       --system-libs \
-       --no-qt-gui \
-       --no-system-libarchive \
-       --no-system-jsoncpp \
-       --parallel=${CPU_COUNT} \
-       -- \
-       ${CMAKE_ARGS}
-fi
-
-# CMake automatically selects the highest C++ standard available
-
-make install -j${CPU_COUNT}
+cmake --build . --target install -j${CPU_COUNT}
+ctest --output-on-failure -j${CPU_COUNT} -R "CTestTestParallel|DOWNLOAD"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - make            # [unix]
+    - cmake-no-system  # [unix]
 
   host:
     - bzip2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.26.4" %}
+{% set version = "3.31.2" %}
 
 package:
   name: cmake
@@ -6,9 +6,9 @@ package:
 
 source:
   - url: https://github.com/Kitware/CMake/releases/download/v{{ version }}/cmake-{{ version }}.tar.gz
-    sha256: 313b6880c291bd4fe31c0aa51d6e62659282a521e695f30d5cc0d25abbd5c208
+    sha256: 42abb3f48f37dbd739cdfeb19d3712db0c5935ed5c2aef6c340f9ae9114238a2
   - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows-x86_64.zip  # [win64]
-    sha256: 62c35427104a4f8205226f72708d71334bd36a72cf72c60d0e3a766d71dcc78a  # [win64]
+    sha256: 109c29a744d648863d3637b4963c90088045c8d92799c68c9b9d8713407776c8  # [win64]
     folder: cmake-bin  # [win]
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake-no-system  # [unix]
+    - ninja
 
   host:
     - bzip2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ build:
   number: 0
   ignore_run_exports:
     - vc
+  missing_dso_whitelist:  # [s390x]
+    - $RPATH/ld64.so.1    # [s390x] Known s390x `ld64.so` issue.
 
 requirements:
   build:


### PR DESCRIPTION
cake 3.31.2

**Destination channel:**  defaults

### Links

- [PKG-5133](https://anaconda.atlassian.net/browse/PKG-5133) 
- [Upstream repository](https://github.com/Kitware/CMake/tree/v3.31.2)
- [Upstream changelog/diff](https://cmake.org/cmake/help/latest/release/3.31.html)

### Explanation of changes:

- Switch to building cmake using an older version rather than bootstrapping. 
- Prefer Ninja over makefiles



[PKG-5133]: https://anaconda.atlassian.net/browse/PKG-5133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ