### PR TITLE
Win arm64

### DIFF
--- a/recipe/SSLTest.cmake
+++ b/recipe/SSLTest.cmake
@@ -1,6 +1,6 @@
 set(FILE_NAME "LICENSE.txt")
 set(DOWNLOAD_URL "https://raw.githubusercontent.com/conda-forge/cmake-feedstock/master/${FILE_NAME}")
-set(EXPECTED_SHA256 "86dc4bc79c9fa4d5dc3ae5558441d5bb8b8736403e70997cf9ae8f671ab5d0ca")
+set(EXPECTED_SHA256 "b76585ad68860b271fc4c5a346444e4a70cacd48a3fd688cb2e8dd18d5935cd1")
 
 file(DOWNLOAD ${DOWNLOAD_URL} ${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}
  SHOW_PROGRESS

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -27,7 +27,7 @@ cmake -LAH -G Ninja                                          ^
     -DCMAKE_USE_SYSTEM_BZIP2=TRUE                            ^
     -DZLIB_LIBRARY="%LIBRARY_LIB%\zlib.lib"                  ^
     -DZLIB_INCLUDE_DIR="%LIBRARY_INC%"                       ^
-    -DLIBLZMA_LIBRARY:FILEPATH="%LIBRARY_LIB%\liblzma.lib"   ^
+    -DLIBLZMA_LIBRARY:FILEPATH="%LIBRARY_LIB%\lzma.lib"   ^
     -DBZIP2_INCLUDE_DIR="%LIBRARY_INC%"                      ^
     -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ..
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,18 +7,20 @@ package:
 source:
   - url: https://github.com/Kitware/CMake/releases/download/v{{ version }}/cmake-{{ version }}.tar.gz
     sha256: 42abb3f48f37dbd739cdfeb19d3712db0c5935ed5c2aef6c340f9ae9114238a2
-  - url: https://cmake.org/files/v{{ version[:4] }}/cmake-{{ version }}-windows-x86_64.zip  # [win64]
-    sha256: 109c29a744d648863d3637b4963c90088045c8d92799c68c9b9d8713407776c8  # [win64]
-    folder: cmake-bin  # [win]
+  - url: https://github.com/Kitware/CMake/releases/download/v{{ version }}/cmake-{{ version }}-windows-x86_64.zip  # [win and x86_64]
+    sha256: 109c29a744d648863d3637b4963c90088045c8d92799c68c9b9d8713407776c8  # [win and x86_64]
+    folder: cmake-bin  # [win and x86_64]
+  - url: https://github.com/Kitware/CMake/releases/download/v{{ version }}/cmake-{{ version }}-windows-arm64.zip  # [win and arm64]
+    sha256: 909b8c354a96dd261c395e29045e379a3fd41af81ae449c67e66550d59ed43ba  # [win and arm64]
+    folder: cmake-bin  # [win and arm64]
 build:
-  number: 0
+  number: 1
   ignore_run_exports:
     - vc
-  missing_dso_whitelist:  # [s390x]
-    - $RPATH/ld64.so.1    # [s390x] Known s390x `ld64.so` issue.
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake-no-system  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,6 @@ requirements:
     - libuv
     - rhash           # [unix]
     - zstd
-    - vs2015_runtime  # [win]
 test:
   files:
     - SSLTest.cmake

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     sha256: 909b8c354a96dd261c395e29045e379a3fd41af81ae449c67e66550d59ed43ba  # [win and arm64]
     folder: cmake-bin  # [win and arm64]
 build:
-  number: 1
+  number: 2
   ignore_run_exports:
     - vc
 


### PR DESCRIPTION
cmake rebuild win-arm64 support

**Destination channel:** defaults

### Links

- [PKG-15350](https://anaconda.atlassian.net/browse/PKG-15350) 

### Explanation of changes:

- Add win-arm64 sources
- Bump build number
- Removes unneeded runtime on windows. 
- Fix fragile test

[PKG-15350]: https://anaconda.atlassian.net/browse/PKG-15350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ