### PR TITLE
win-arm64 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,9 @@ source:
   - url: https://github.com/Kitware/CMake/releases/download/v{{ version }}/{{ name }}-{{ version }}-windows-x86_64.zip  # [win and x86_64]
     sha256: 86e5fcafb38bdf58346a78b187c7b6b4f252ae5242cffe24c463a92bbd2e77d1 # [win and x86_64]
     folder: cmake-bin  # [win and x86_64]
+  - url: https://github.com/Kitware/CMake/releases/download/v{{ version }}/cmake-{{ version }}-windows-arm64.zip  # [win and arm64]
+    sha256: 909b8c354a96dd261c395e29045e379a3fd41af81ae449c67e66550d59ed43ba  # [win and arm64]
+    folder: cmake-bin  # [win and arm64]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: 86e5fcafb38bdf58346a78b187c7b6b4f252ae5242cffe24c463a92bbd2e77d1 # [win and x86_64]
     folder: cmake-bin  # [win and x86_64]
   - url: https://github.com/Kitware/CMake/releases/download/v{{ version }}/cmake-{{ version }}-windows-arm64.zip  # [win and arm64]
-    sha256: 909b8c354a96dd261c395e29045e379a3fd41af81ae449c67e66550d59ed43ba  # [win and arm64]
+    sha256: 91a59ca6ffbcec18e1fb05431fa22f538ab615b6e525d1bfd0b8dd67a4d45685  # [win and arm64]
     folder: cmake-bin  # [win and arm64]
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     folder: cmake-bin  # [win and arm64]
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports:
     - vc
 


### PR DESCRIPTION
rebuild cmake: add win-arm64 support

Fixes win-arm64: https://package-build.anaconda.com/v1/graph/2dff43cc-c9e7-45ff-b17c-8520f7c7d192